### PR TITLE
Update command registration to match new atom API

### DIFF
--- a/lib/switcheroo.coffee
+++ b/lib/switcheroo.coffee
@@ -5,7 +5,7 @@ module.exports =
   }
 
   activate: (state) ->
-    atom.workspaceView.command "switcheroo:toggle", => @toggle()
+    atom.commands.add "atom-workspace", "switcheroo:toggle", => @toggle()
 
   toggle: ->
     @currentTheme = atom.config.get('core.themes')

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "main": "./lib/switcheroo",
   "version": "0.5.0",
   "description": "Switch between your 2 favorite themes",
-  "activationEvents": [
-    "switcheroo:toggle"
-  ],
   "repository": "https://github.com/adrianolaru/switcheroo",
   "license": "MIT",
   "engines": {

--- a/spec/switcheroo-spec.coffee
+++ b/spec/switcheroo-spec.coffee
@@ -6,27 +6,21 @@
 # or `fdescribe`). Remove the `f` to unfocus the block.
 
 describe 'Switcheroo', ->
-  activationPromise = null
-
   beforeEach ->
-    atom.workspaceView = new WorkspaceView()
-    atom.workspaceView.attachToDom()
-    activationPromise = atom.packages.activatePackage('switcheroo')
+    waitsForPromise ->
+      atom.packages.activatePackage('switcheroo')
 
   describe "when the switcheroo:toggle event is triggered", ->
     it "toggle theme", ->
+      workspaceView = atom.views.getView(atom.workspace)
       defaultTheme = atom.config.get('core.themes')
-      atom.workspaceView.trigger 'switcheroo:toggle'
+      atom.commands.dispatch workspaceView, 'switcheroo:toggle'
 
-      waitsForPromise ->
-        activationPromise
+      theme = atom.config.get('core.themes')
+      expect(theme).not.toEqual(defaultTheme)
 
-      runs ->
-        theme = atom.config.get('core.themes')
-        expect(theme).not.toEqual(defaultTheme)
+      expect(theme).toEqual(atom.config.get('switcheroo.themeOne'))
 
-        expect(theme).toEqual(atom.config.get('switcheroo.themeTwo'))
-
-        atom.workspaceView.trigger 'switcheroo:toggle'
-        theme = atom.config.get('core.themes')
-        expect(theme).toEqual(atom.config.get('switcheroo.themeOne'))
+      atom.commands.dispatch workspaceView, 'switcheroo:toggle'
+      theme = atom.config.get('core.themes')
+      expect(theme).toEqual(atom.config.get('switcheroo.themeTwo'))


### PR DESCRIPTION
Fixes #2

This package doesn't work in the newer versions of Atom. This commit makes it work again.
